### PR TITLE
Add logic to close db connections after testing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run lint ${{matrix.app}}
 
       - name: Test
-        run: npm test ${{matrix.app}} --runInBand
+        run: npm test ${{matrix.app}}
 
   test-e2e:
     needs: [audit]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Wait for DB to be ready
         uses: jakejarvis/wait-action@master
         with:
-          time: '30s'
+          time: '60s'
 
       - name: Test
         run: npm run nx serve api & npm run e2e

--- a/apps/api/src/app/routes/users/users.controller.spec.ts
+++ b/apps/api/src/app/routes/users/users.controller.spec.ts
@@ -3,7 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 
-import { rootMongooseTestModule } from '../../../tests/tests.utils';
+import { closeInMongodbConnections, rootMongooseTestModule } from '../../../tests/tests.utils';
 
 import { User, UserSchema } from './user.schema';
 import { UsersController } from './users.controller';
@@ -33,6 +33,10 @@ describe('UsersController', () => {
 
     afterEach(async () => {
         await app.close();
+    });
+
+    afterAll(async () => {
+        await closeInMongodbConnections();
     });
 
     describe('/GET users', () => {

--- a/apps/api/src/app/routes/users/users.service.spec.ts
+++ b/apps/api/src/app/routes/users/users.service.spec.ts
@@ -3,7 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Types } from 'mongoose';
 
-import { rootMongooseTestModule } from '../../../tests/tests.utils';
+import { closeInMongodbConnections, rootMongooseTestModule } from '../../../tests/tests.utils';
 
 import { User, UserSchema } from './user.schema';
 import { UsersService } from './users.service';
@@ -30,8 +30,12 @@ describe('UsersService', () => {
         await app.close();
     });
 
+    afterAll(async () => {
+        await closeInMongodbConnections();
+    });
+
     describe('getUser', () => {
-        it('throws NotFoundException on unknown id', async () => {
+        it('returns null on unknown id', async () => {
             expect.assertions(1);
             const id = Types.ObjectId().toHexString();
             await expect(service.getUser(id)).resolves.toBeNull();

--- a/apps/api/src/tests/tests.utils.ts
+++ b/apps/api/src/tests/tests.utils.ts
@@ -1,13 +1,14 @@
 import { MongooseModule, MongooseModuleOptions } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 
-let mongodb: MongoMemoryServer;
+const dbs: MongoMemoryServer[] = [];
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const rootMongooseTestModule = (options: MongooseModuleOptions = {}) => MongooseModule.forRootAsync({
     useFactory: async () => {
-        mongodb = new MongoMemoryServer();
+        const mongodb = new MongoMemoryServer();
         const mongoUri = await mongodb.getUri();
+        dbs.push(mongodb);
         return {
             uri: mongoUri,
             useCreateIndex: true,
@@ -16,8 +17,8 @@ export const rootMongooseTestModule = (options: MongooseModuleOptions = {}) => M
     },
 });
 
-export const closeInMongodbConnection = async (): Promise<void> => {
-    if (mongodb) {
-        await mongodb.stop();
-    }
+export const closeInMongodbConnections = async (): Promise<void> => {
+    await Promise.all(dbs.map(async (db) => {
+        await db.stop();
+    }));
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "nx": "nx",
         "start": "ng serve",
         "build": "ng build",
-        "test": "ng test",
+        "test": "ng test -- --run-in-band",
         "lint": "nx workspace-lint && ng lint",
         "e2e": "ng e2e",
         "affected:apps": "nx affected:apps",


### PR DESCRIPTION
So Jest doesn't complain about open handles: "`A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.`"